### PR TITLE
On update throw instead of return null when no fields are provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baselinejs/dynamodb",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "BaselineJS",
   "description": "DynamoDB library for simple and optimized way to use AWS DynamoDB",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ export const updateItem = async <
   T extends Record<string, NativeAttributeValue>,
 >(
   params: UpdateItemParams<T>,
-): Promise<T | null> => {
+): Promise<T> => {
   const updateItems: UpdateItem[] = [];
 
   let count = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,8 +139,6 @@ export interface UpdateItemParams<
 /**
  * Update attributes on an item.
  *
- * Returns null if no fields are to be updated or deleted.
- *
  * Specify "fields" for the attributes to update.
  *
  * Specify "removeFields" for the attributes to remove from the item.
@@ -182,7 +180,7 @@ export const updateItem = async <
   }
 
   if (!updateItems.length && !removeAttributeItems.length) {
-    return null;
+    throw new Error('No fields or removeFields provided to updateItem');
   }
 
   let updateExpression = '';


### PR DESCRIPTION
On update throw instead of return null when no fields are provided. This resolves the need to check if null is returned where the bare minimum fields required to do an update are not provided. This means we can rely on a record being returned or expect a throw.